### PR TITLE
Use shell stylesheet and add base HTML import

### DIFF
--- a/build_transtype-kindle_template.xml
+++ b/build_transtype-kindle_template.xml
@@ -15,7 +15,7 @@
     xmlns:dita="http://dita-ot.sourceforge.net"
     >
 
-    <property name="args.xsl" location="${dita.dir}/plugins/org.dita4publishers.kindle/xsl/map2kindleImpl.xsl"/>
+    <property name="args.xsl" location="${dita.dir}/plugins/org.dita4publishers.kindle/xsl/map2kindle.xsl"/>
     <antcall target="dita2epub">
       <param name="args.xsl" value="${args.xsl}"/>
       <param name="d4p.epubtype" value="epub3" /> <!-- currently generating epub3, might need

--- a/xsl/map2kindle_template.xsl
+++ b/xsl/map2kindle_template.xsl
@@ -4,6 +4,7 @@
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+  <xsl:import href="plugin:org.dita.xhtml:xsl/dita2xhtml.xsl"/>
   <xsl:import href="map2kindleImpl.xsl"/> 
   
   <dita:extension id="xsl.transtype-kindle"   


### PR DESCRIPTION
* Use shell stylesheet in `args.xsl` instead of implementation stylesheet.
* After dita4publishers/org.dita4publishers.epub#81 the implementation stylesheet no longer imports base HTML plugin, adding missing import.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>