### PR TITLE
Move Kindle properties to kindle target for lazy initialisation

### DIFF
--- a/build_transtype-kindle_template.xml
+++ b/build_transtype-kindle_template.xml
@@ -2,14 +2,6 @@
   >
   <!-- NOTE: This build file depends on targets defined in the epub transtype -->
   
-	<!-- Global properties that affect the base Toolkit processing go before the target elem: -->
-  
-  <condition property="kindlegen.executable" value="kindlegen">
-    <not><isset property="kindlegen.executable"></isset></not>
-  </condition>
-  <property name="kindlegen.executable" value="${kindlegen.executable}"></property>
-  <property name="kindlegenArgs" value=""></property>
-  
   <target name="dita2kindle"
     unless="noMap"
     xmlns:dita="http://dita-ot.sourceforge.net"
@@ -29,6 +21,11 @@
   </target> 
   
   <target name="kindlegen">
+    <condition property="kindlegen.executable" value="kindlegen">
+      <not><isset property="kindlegen.executable"></isset></not>
+    </condition>
+    <property name="kindlegen.executable" value="${kindlegen.executable}"></property>
+    <property name="kindlegenArgs" value=""></property>
     <!-- I am not sure why we need to get the args.input etc. again. That is I am not sure why
       the dita.map.filename.root property is not available. Something about ant order of operations
       that I am not getting. -->


### PR DESCRIPTION
When Kindle properties are initialized at top level, they can only be overridden by creating a new project with `<antcall>` or provided as user properties from the command line.

This moves the Kindle properties to be initialised in the `kindlegen` target where they are used. This allows maximum flexibility wrt overriding the defaults.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>